### PR TITLE
feat: load env variables in client

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,2 @@
+JWT_ISSUER=https://tokens.talos.local/
+JWT_AUDIENCE=apiserver

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "dotenv": "^17.2.2",
     "express": "^4.19.2",
     "http-proxy-middleware": "^2.0.6",
     "jsonwebtoken": "^9.0.2"

--- a/client/server.js
+++ b/client/server.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 const express = require("express");
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const fs = require("fs");


### PR DESCRIPTION
## Summary
- load env vars from `.env` in client proxy
- document JWT issuer and audience defaults

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm test` (internal-api) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c732b5ceac8333a3cd2aff3f19a52a